### PR TITLE
Update - ambiguity fix and tweak from develop branch

### DIFF
--- a/assets/ui/NotificationOverlay.ui
+++ b/assets/ui/NotificationOverlay.ui
@@ -1,8 +1,8 @@
 {
-    "type" : "Dialogs:NotificationOverlay",
+    "type" : "Dialogs:DialogNotificationOverlay",
     "contents" : {
         "type" : "relativeLayout",
-        "skin" : "NotificationOverlay",
+        "skin" : "DialogNotificationOverlay",
         "contents" : [
             {
                 "type" : "columnLayout",

--- a/module.txt
+++ b/module.txt
@@ -3,7 +3,7 @@
     "version" : "0.1.0-SNAPSHOT",
     "author" : "msteiger",
     "displayName" : "Dialogs",
-    "description" : "Add in-game dialogs",
+    "description" : "Add in-game dialogs between player and NPC",
     "dependencies" : [],
     "serverSideOnly" : false
 }

--- a/module.txt
+++ b/module.txt
@@ -1,6 +1,6 @@
 {
     "id" : "Dialogs",
-    "version" : "0.1.0-SNAPSHOT",
+    "version" : "0.1.1-SNAPSHOT",
     "author" : "msteiger",
     "displayName" : "Dialogs",
     "description" : "Add in-game dialogs between player and NPC",

--- a/src/main/java/org/terasology/notify/NotificationSystem.java
+++ b/src/main/java/org/terasology/notify/NotificationSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,24 +21,22 @@ import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.notify.ui.NotificationEvent;
-import org.terasology.notify.ui.NotificationOverlay;
+import org.terasology.notify.ui.DialogNotificationOverlay;
 import org.terasology.notify.ui.RemoveNotificationEvent;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
 
-/**
- */
 @RegisterSystem(RegisterMode.CLIENT)
 public class NotificationSystem extends BaseComponentSystem {
 
     @In
     private NUIManager nuiManager;
 
-    private NotificationOverlay window;
+    private DialogNotificationOverlay window;
 
     @Override
     public void initialise() {
-        window = nuiManager.addOverlay(NotificationOverlay.ASSET_URI, NotificationOverlay.class);
+        window = nuiManager.addOverlay(DialogNotificationOverlay.ASSET_URI, DialogNotificationOverlay.class);
     }
 
     @Override
@@ -56,4 +54,3 @@ public class NotificationSystem extends BaseComponentSystem {
         window.removeNotification(event.getText());
     }
 }
-

--- a/src/main/java/org/terasology/notify/ui/DialogNotificationOverlay.java
+++ b/src/main/java/org/terasology/notify/ui/DialogNotificationOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 MovingBlocks
+ * Copyright 2018 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,11 +29,9 @@ import org.terasology.rendering.nui.databinding.DefaultBinding;
 import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.rendering.nui.widgets.UIList;
 
-/**
- */
-public class NotificationOverlay extends CoreScreenLayer {
+public class DialogNotificationOverlay extends CoreScreenLayer {
 
-    public static final ResourceUrn ASSET_URI = new ResourceUrn("Dialogs:NotificationOverlay");
+    public static final ResourceUrn ASSET_URI = new ResourceUrn("Dialogs:DialogNotificationOverlay");
 
     @In
     private Time time;


### PR DESCRIPTION
Without the ambiguity fix a clash with a like-named UI in the engine appeared to cause runtime NPEs and instability. Despite them being in different namespaces. That must not be good enough in some cases.