### PR TITLE
fix: wrong image column height when more options

### DIFF
--- a/assets/ui/DialogScreen.ui
+++ b/assets/ui/DialogScreen.ui
@@ -26,7 +26,6 @@
                     {
                         "type": "ColumnLayout",
                         "id": "responseImage",
-                        "family": "imageColumn",
                         "layoutInfo": {
                             "use-content-height": true,
                             "use-content-width": true,

--- a/src/main/java/org/terasology/dialogs/DialogScreen.java
+++ b/src/main/java/org/terasology/dialogs/DialogScreen.java
@@ -71,6 +71,7 @@ public class DialogScreen extends CoreScreenLayer {
         UIImage newImage = new UIImage();
         newButton.setText(text);
         newImage.setImage(image);
+        newImage.setFamily("imageColumn");
         newImage.bindVisible(new ReadOnlyBinding<Boolean>() {
             @Override
             public Boolean get() {


### PR DESCRIPTION
## Associated
This PR fixes the same issue but within LAS: https://github.com/Terasology/LightAndShadow/pull/156


## Issue

I had a `family` at the UI file which set the fixed size of the AnswerImages. I had set this size to the column instead of the images themselves. I corrected that mistake.

