### PR TITLE
fix: NotificationOverlay visibility and alignment

### DIFF
--- a/assets/ui/NotificationOverlay.ui
+++ b/assets/ui/NotificationOverlay.ui
@@ -2,7 +2,7 @@
     "type" : "Dialogs:DialogNotificationOverlay",
     "contents" : {
         "type" : "relativeLayout",
-        "skin" : "DialogNotificationOverlay",
+        "skin" : "Dialogs:NotificationOverlay",
         "contents" : [
             {
                 "type" : "columnLayout",
@@ -15,8 +15,10 @@
                 "layoutInfo" : {
                     "use-content-width" : true,
                     "use-content-height" : true,
-                    "position-right" : {},
-                    "position-top" : {}
+                    "position-horizontal-center" : {},
+                    "position-bottom" : {
+                        "offset": 150
+                    }
                 }
             }
         ]

--- a/src/main/java/org/terasology/dialogs/DialogSystem.java
+++ b/src/main/java/org/terasology/dialogs/DialogSystem.java
@@ -16,7 +16,6 @@ import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.input.Input;
 import org.terasology.input.InputSystem;
-import org.terasology.input.InputType;
 import org.terasology.logic.characters.CharacterComponent;
 import org.terasology.logic.characters.events.ActivationRequest;
 import org.terasology.logic.common.DisplayNameComponent;
@@ -26,12 +25,12 @@ import org.terasology.network.ClientComponent;
 import org.terasology.network.ColorComponent;
 import org.terasology.notify.ui.NotificationEvent;
 import org.terasology.notify.ui.RemoveNotificationEvent;
+import org.terasology.nui.Color;
+import org.terasology.nui.FontColor;
 import org.terasology.persistence.TemplateEngine;
 import org.terasology.persistence.TemplateEngineImpl;
 import org.terasology.registry.In;
-import org.terasology.nui.FontColor;
 import org.terasology.rendering.assets.texture.TextureRegion;
-import org.terasology.nui.Color;
 import org.terasology.rendering.nui.NUIManager;
 import org.terasology.rendering.nui.widgets.browser.data.basic.HTMLLikeParser;
 import org.terasology.rendering.nui.widgets.browser.data.html.HTMLDocument;
@@ -185,21 +184,20 @@ public class DialogSystem extends BaseComponentSystem {
         updateTalkNotification(character, active);
     }
 
+    private String lookupInteractionButton() {
+        List<Input> inputs = inputSystem.getInputsForBindButton(new SimpleUri("engine:frob"));
+        return inputs.stream().findFirst().map(input -> input.getDisplayName()).orElse("n/a");
+    }
+
     private String createTalkText() {
-        SimpleUri id = new SimpleUri("engine:frob");
-        List<Input> inputs = inputSystem.getInputsForBindButton(id);
         String text = "Press ";
-        for (Input input : inputs) {
-            if (input.getType() == InputType.KEY) {
-                String name = input.getDisplayName();
-                if (name.length() == 1) {
-                    int off = name.charAt(0) - 'A';
-                    char code = (char) (EnclosedAlphanumerics.CIRCLED_LATIN_CAPITAL_LETTER_A + off);
-                    text += FontColor.getColored(String.valueOf(code), new Color(0xFFFF00FF));
-                } else {
-                    text += FontColor.getColored(name, new Color(0xFFFF00FF));
-                }
-            }
+        String button = lookupInteractionButton();
+        if (button.length() == 1) {
+            int off = button.charAt(0) - 'A';
+            char code = (char) (EnclosedAlphanumerics.CIRCLED_LATIN_CAPITAL_LETTER_A + off);
+            text += FontColor.getColored(String.valueOf(code), new Color(0xFFFF00FF));
+        } else {
+            text += FontColor.getColored(button, new Color(0xFFFF00FF));
         }
         text += " to talk";
         return text;

--- a/src/main/java/org/terasology/notify/ui/DialogNotificationOverlay.java
+++ b/src/main/java/org/terasology/notify/ui/DialogNotificationOverlay.java
@@ -14,7 +14,7 @@ import org.terasology.nui.widgets.UIList;
 
 public class DialogNotificationOverlay extends CoreScreenLayer {
 
-    public static final ResourceUrn ASSET_URI = new ResourceUrn("Dialogs:DialogNotificationOverlay");
+    public static final ResourceUrn ASSET_URI = new ResourceUrn("Dialogs:NotificationOverlay");
 
     @In
     private Time time;


### PR DESCRIPTION
The notification overlay was not showing for several reasons. On the one hand it attempts to figure out which button the player has to press, leading to a NPE (fixed by MovingBlocks/Terasology#4256), and on the other hand we must have missed some renaming in the past (asset references are wrong).

As I see these dialog-related notifications more like in-game hints I've moved them to the bottom center of the screen. This is in part to prepare for notifications (e.g., in the form of achievements) to appear in the top-right corner without obstructing these in-game hints:

![image](https://user-images.githubusercontent.com/1448874/99794492-89799700-2b2a-11eb-8b49-67245f05851e.png)

Potential follow-up: Extract the in-game hints from Dialogs into a separate module (possibly unify Notifications, Hints, and [WorldlyTooltip](https://github.com/Terasology/WorldlyTooltip)/[WorldlyTooltipAPI](https://github.com/Terasology/WorldlyTooltipAPI) in one configurable module? There's already [InGameHelp](https://github.com/Terasology/InGameHelp)/[InGameHelpAPI](https://github.com/Terasology/InGameHelpAPI)...)